### PR TITLE
Fix `push-hf` command in CLI

### DIFF
--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -519,10 +519,13 @@ def _export_checkpoint_to_hub(
                 f"Found {existing_tinker_path}, expected {tinker_path}.",
             )
 
+        # Remove checkpoint_complete file before upload if no allow_patterns specified
+        # Workaround: huggingface_hub (which uses typer internally) conflicts with
+        # our Click-based CLI when "checkpoint_complete" is in ignore_patterns
         if allow_patterns is None:
-            ignore_patterns = list(ignore_patterns) if ignore_patterns else []
-            if "checkpoint_complete" not in ignore_patterns:
-                ignore_patterns.append("checkpoint_complete")
+            checkpoint_complete_file = extract_dir / "checkpoint_complete"
+            if checkpoint_complete_file.exists():
+                checkpoint_complete_file.unlink()
 
         api.upload_folder(
             folder_path=os.fspath(extract_dir),

--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -498,15 +498,15 @@ def _export_checkpoint_to_hub(
         # Create the revision/branch if specified and it doesn't exist
         if revision:
             try:
-                # Check if the branch exists
                 refs = api.list_repo_refs(repo_id=repo_id)
                 branch_exists = any(ref.name == revision for ref in refs.branches)
                 if not branch_exists:
-                    # Create the branch from main
                     api.create_branch(repo_id=repo_id, branch=revision, exist_ok=True)
-            except Exception:
-                # If we can't check or create the branch, try to proceed anyway
-                pass
+            except Exception as e:
+                raise TinkerCliError(
+                    f"Failed to create branch {revision} in repo {repo_id}",
+                    f"Error: {e}",
+                ) from e
 
         def _readme_tinker_path() -> str | None:
             try:

--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -335,7 +335,6 @@ def _export_checkpoint_to_hub(
     create_pr: bool,
     exist_ok: bool,
     allow_patterns: list[str] | None,
-    ignore_patterns: list[str] | None,
     add_model_card: bool,
 ) -> str:
     # Lazy imports to keep CLI startup fast
@@ -533,12 +532,9 @@ def _export_checkpoint_to_hub(
             )
 
         # Remove checkpoint_complete file before upload if no allow_patterns specified
-        # Workaround: huggingface_hub (which uses typer internally) conflicts with
-        # our Click-based CLI when "checkpoint_complete" is in ignore_patterns
         if allow_patterns is None:
             checkpoint_complete_file = extract_dir / "checkpoint_complete"
-            if checkpoint_complete_file.exists():
-                checkpoint_complete_file.unlink()
+            checkpoint_complete_file.unlink(missing_ok=True)
 
         api.upload_folder(
             folder_path=os.fspath(extract_dir),
@@ -548,7 +544,6 @@ def _export_checkpoint_to_hub(
             commit_message=commit_message,
             create_pr=create_pr,
             allow_patterns=list(allow_patterns) if allow_patterns else None,
-            ignore_patterns=list(ignore_patterns) if ignore_patterns else None,
         )
 
     return repo_id
@@ -1020,12 +1015,6 @@ def download(
     help="Only upload files matching this pattern (can be repeated).",
 )
 @click.option(
-    "--ignore-pattern",
-    "ignore_patterns",
-    multiple=True,
-    help="Skip files matching this pattern (can be repeated).",
-)
-@click.option(
     "--no-model-card",
     is_flag=True,
     help="Do not create a README.md model card if one is missing.",
@@ -1041,7 +1030,6 @@ def push_hf(
     commit_message: str | None,
     create_pr: bool,
     allow_patterns: tuple[str, ...],
-    ignore_patterns: tuple[str, ...],
     no_model_card: bool,
 ) -> None:
     """Upload a checkpoint to the Hugging Face Hub as a PEFT adapter.
@@ -1066,7 +1054,6 @@ def push_hf(
         create_pr=create_pr,
         exist_ok=True,
         allow_patterns=list(allow_patterns) if allow_patterns else None,
-        ignore_patterns=list(ignore_patterns) if ignore_patterns else None,
         add_model_card=not no_model_card,
     )
 

--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -495,6 +495,19 @@ def _export_checkpoint_to_hub(
 
         api.create_repo(repo_id=repo_id, private=private, exist_ok=exist_ok)
 
+        # Create the revision/branch if specified and it doesn't exist
+        if revision:
+            try:
+                # Check if the branch exists
+                refs = api.list_repo_refs(repo_id=repo_id)
+                branch_exists = any(ref.name == revision for ref in refs.branches)
+                if not branch_exists:
+                    # Create the branch from main
+                    api.create_branch(repo_id=repo_id, branch=revision, exist_ok=True)
+            except Exception:
+                # If we can't check or create the branch, try to proceed anyway
+                pass
+
         def _readme_tinker_path() -> str | None:
             try:
                 readme_file = hf_hub_download(

--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -336,10 +336,11 @@ def _export_checkpoint_to_hub(
     exist_ok: bool,
     allow_patterns: list[str] | None,
     add_model_card: bool,
+    overwrite: bool,
 ) -> str:
     # Lazy imports to keep CLI startup fast
     try:
-        from huggingface_hub import HfApi, hf_hub_download
+        from huggingface_hub import HfApi
     except ImportError as exc:
         raise TinkerCliError(
             "huggingface_hub is required for this command.",
@@ -348,7 +349,6 @@ def _export_checkpoint_to_hub(
 
     import json
     import os
-    import re
     import tempfile
     from pathlib import Path
 
@@ -494,57 +494,75 @@ def _export_checkpoint_to_hub(
 
         api.create_repo(repo_id=repo_id, private=private, exist_ok=exist_ok)
 
-        # Create the revision/branch if specified and it doesn't exist
-        if revision:
+        # Helper function to get branch names
+        def _get_branch_names() -> set[str]:
             try:
                 refs = api.list_repo_refs(repo_id=repo_id)
-                branch_exists = any(ref.name == revision for ref in refs.branches)
-                if not branch_exists:
-                    api.create_branch(repo_id=repo_id, branch=revision, exist_ok=True)
-            except Exception as e:
-                raise TinkerCliError(
-                    f"Failed to create branch {revision} in repo {repo_id}",
-                    f"Error: {e}",
-                ) from e
+                return {ref.name for ref in refs.branches}
+            except Exception:
+                return set()
 
-        def _readme_tinker_path() -> str | None:
-            try:
-                readme_file = hf_hub_download(
+        # Create the revision/branch if specified and it doesn't exist
+        try:
+            branch_names = _get_branch_names()
+            target_revision = revision or "main"
+            uploaded_to_target = False
+
+            # Ensure main branch has content if it doesn't exist
+            # Upload the actual checkpoint instead of a minimal README
+            if "main" not in branch_names:
+                api.upload_folder(
+                    folder_path=os.fspath(extract_dir),
                     repo_id=repo_id,
-                    filename="README.md",
-                    revision=revision,
-                    token=None,
+                    path_in_repo="",
+                    revision="main",
+                    commit_message=commit_message or "Upload checkpoint from Tinker",
+                    create_pr=False,
+                    allow_patterns=list(allow_patterns) if allow_patterns else None,
                 )
-            except Exception:
-                return None
-            try:
-                text = Path(readme_file).read_text(encoding="utf-8", errors="ignore")
-            except Exception:
-                return None
-            match = re.search(r"tinker://[^\s`]+", text)
-            return match.group(0) if match else None
+                branch_names = _get_branch_names()
 
-        existing_tinker_path = _readme_tinker_path()
-        if existing_tinker_path and existing_tinker_path != tinker_path:
+                if target_revision == "main":
+                    # We've uploaded to the target already
+                    uploaded_to_target = True
+                else:
+                    # Create the target revision branch from main (which now has content)
+                    # This avoids uploading the same content twice
+                    if target_revision not in branch_names:
+                        api.create_branch(repo_id=repo_id, branch=target_revision, exist_ok=True)
+                    uploaded_to_target = True
+            else:
+                # Main exists, so we need to create the target branch if needed
+                if target_revision != "main" and target_revision not in branch_names:
+                    api.create_branch(repo_id=repo_id, branch=target_revision, exist_ok=True)
+        except Exception as e:
             raise TinkerCliError(
-                "Repo ID appears to contain a different Tinker checkpoint.",
-                f"Found {existing_tinker_path}, expected {tinker_path}.",
-            )
+                f"Failed to prepare revision {revision or 'main'} in repo {repo_id}",
+                f"Error: {e}",
+            ) from e
 
         # Remove checkpoint_complete file before upload if no allow_patterns specified
         if allow_patterns is None:
             checkpoint_complete_file = extract_dir / "checkpoint_complete"
             checkpoint_complete_file.unlink(missing_ok=True)
 
-        api.upload_folder(
-            folder_path=os.fspath(extract_dir),
-            repo_id=repo_id,
-            path_in_repo="",
-            revision=revision,
-            commit_message=commit_message,
-            create_pr=create_pr,
-            allow_patterns=list(allow_patterns) if allow_patterns else None,
-        )
+        # Upload to target revision if we haven't already
+        if not uploaded_to_target:
+            # Check if we would be overwriting an existing branch
+            if not overwrite and target_revision in branch_names:
+                raise TinkerCliError(
+                    f"Branch '{target_revision}' already exists in repo {repo_id}",
+                    "Use --overwrite to replace the existing branch, or specify a different --revision",
+                )
+            api.upload_folder(
+                folder_path=os.fspath(extract_dir),
+                repo_id=repo_id,
+                path_in_repo="",
+                revision=target_revision,
+                commit_message=commit_message,
+                create_pr=create_pr,
+                allow_patterns=list(allow_patterns) if allow_patterns else None,
+            )
 
     return repo_id
 
@@ -1019,6 +1037,11 @@ def download(
     is_flag=True,
     help="Do not create a README.md model card if one is missing.",
 )
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help="Allow overwriting an existing branch (default: False).",
+)
 @click.pass_obj
 @handle_api_errors
 def push_hf(
@@ -1031,6 +1054,7 @@ def push_hf(
     create_pr: bool,
     allow_patterns: tuple[str, ...],
     no_model_card: bool,
+    overwrite: bool,
 ) -> None:
     """Upload a checkpoint to the Hugging Face Hub as a PEFT adapter.
 
@@ -1055,6 +1079,7 @@ def push_hf(
         exist_ok=True,
         allow_patterns=list(allow_patterns) if allow_patterns else None,
         add_model_card=not no_model_card,
+        overwrite=overwrite,
     )
 
     output_obj = CheckpointHubUploadOutput(

--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -543,8 +543,7 @@ def _export_checkpoint_to_hub(
 
         # Remove checkpoint_complete file before upload if no allow_patterns specified
         if allow_patterns is None:
-            checkpoint_complete_file = extract_dir / "checkpoint_complete"
-            checkpoint_complete_file.unlink(missing_ok=True)
+            checkpoint_complete.unlink(missing_ok=True)
 
         # Upload to target revision if we haven't already
         if not uploaded_to_target:

--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -492,7 +492,13 @@ def _export_checkpoint_to_hub(
             model_card.append("")
             readme_path.write_text("\n".join(model_card), encoding="utf-8")
 
-        api.create_repo(repo_id=repo_id, private=private, exist_ok=exist_ok)
+        if api.repo_exists(repo_id=repo_id):
+            repo_was_created = False
+            if not exist_ok:
+                raise TinkerCliError(f"Repository {repo_id} already exists")
+        else:
+            api.create_repo(repo_id=repo_id, private=private, exist_ok=False)
+            repo_was_created = True
 
         def _get_branch_names() -> set[str]:
             try:
@@ -542,7 +548,7 @@ def _export_checkpoint_to_hub(
             checkpoint_complete.unlink(missing_ok=True)
 
         if not uploaded_to_target:
-            if not overwrite and target_revision in branch_names:
+            if not repo_was_created and not overwrite and target_revision in branch_names:
                 raise TinkerCliError(
                     f"Branch '{target_revision}' already exists in repo {repo_id}",
                     "Use --overwrite to add a new commit to the existing branch, "

--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -507,6 +507,12 @@ def _export_checkpoint_to_hub(
             uploaded_to_target = False
 
             if "main" not in branch_names:
+                if create_pr:
+                    click.echo(
+                        "Warning: --create-pr was requested, but this upload is creating a new repository. "
+                        "Uploading content to 'main' without a PR.",
+                        err=True,
+                    )
                 api.upload_folder(
                     folder_path=os.fspath(extract_dir),
                     repo_id=repo_id,
@@ -539,7 +545,8 @@ def _export_checkpoint_to_hub(
             if not overwrite and target_revision in branch_names:
                 raise TinkerCliError(
                     f"Branch '{target_revision}' already exists in repo {repo_id}",
-                    "Use --overwrite to replace the existing branch, or specify a different --revision",
+                    "Use --overwrite to add a new commit to the existing branch, "
+                    "or specify a different --revision",
                 )
             api.upload_folder(
                 folder_path=os.fspath(extract_dir),
@@ -1027,7 +1034,7 @@ def download(
 @click.option(
     "--overwrite",
     is_flag=True,
-    help="Allow overwriting an existing branch (default: False).",
+    help="Allow uploading a new commit to an existing branch (default: False).",
 )
 @click.pass_obj
 @handle_api_errors
@@ -1046,6 +1053,8 @@ def push_hf(
     """Upload a checkpoint to the Hugging Face Hub as a PEFT adapter.
 
     CHECKPOINT_PATH must be a tinker path (e.g., tinker://run-id/sampler_weights/0001).
+    If --overwrite is set and the target branch exists, this command uploads a new commit
+    to that branch (it does not replace branch history).
     """
     # Validate it's a tinker path
     if not checkpoint_path.startswith("tinker://"):

--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -494,7 +494,6 @@ def _export_checkpoint_to_hub(
 
         api.create_repo(repo_id=repo_id, private=private, exist_ok=exist_ok)
 
-        # Helper function to get branch names
         def _get_branch_names() -> set[str]:
             try:
                 refs = api.list_repo_refs(repo_id=repo_id)
@@ -502,14 +501,11 @@ def _export_checkpoint_to_hub(
             except Exception:
                 return set()
 
-        # Create the revision/branch if specified and it doesn't exist
         try:
             branch_names = _get_branch_names()
             target_revision = revision or "main"
             uploaded_to_target = False
 
-            # Ensure main branch has content if it doesn't exist
-            # Upload the actual checkpoint instead of a minimal README
             if "main" not in branch_names:
                 api.upload_folder(
                     folder_path=os.fspath(extract_dir),
@@ -523,31 +519,23 @@ def _export_checkpoint_to_hub(
                 branch_names = _get_branch_names()
 
                 if target_revision == "main":
-                    # We've uploaded to the target already
                     uploaded_to_target = True
                 else:
-                    # Create the target revision branch from main (which now has content)
-                    # This avoids uploading the same content twice
                     if target_revision not in branch_names:
                         api.create_branch(repo_id=repo_id, branch=target_revision, exist_ok=True)
                     uploaded_to_target = True
-            else:
-                # Main exists, so we need to create the target branch if needed
-                if target_revision != "main" and target_revision not in branch_names:
-                    api.create_branch(repo_id=repo_id, branch=target_revision, exist_ok=True)
-        except Exception as e:
+            elif target_revision != "main" and target_revision not in branch_names:
+                api.create_branch(repo_id=repo_id, branch=target_revision, exist_ok=True)
+        except Exception as exc:
             raise TinkerCliError(
                 f"Failed to prepare revision {revision or 'main'} in repo {repo_id}",
-                f"Error: {e}",
-            ) from e
+                f"Error: {exc}",
+            ) from exc
 
-        # Remove checkpoint_complete file before upload if no allow_patterns specified
         if allow_patterns is None:
             checkpoint_complete.unlink(missing_ok=True)
 
-        # Upload to target revision if we haven't already
         if not uploaded_to_target:
-            # Check if we would be overwriting an existing branch
             if not overwrite and target_revision in branch_names:
                 raise TinkerCliError(
                     f"Branch '{target_revision}' already exists in repo {repo_id}",


### PR DESCRIPTION
This PR fixes two issues when using the `push-hf` command in the CLI:
1. Fixes how we dealt with the checkpoint_complete file because the previous version conflicted with the Click CLI.
2. The previous version required having the revision already available in the Hugging Face Hub. We now create the revision if it's not already available. 