### PR TITLE
fix: prevent exponential backoff on poll timeouts during result retrieval

### DIFF
--- a/src/tinker/lib/api_future_impl.py
+++ b/src/tinker/lib/api_future_impl.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Type, TypeVar, cast
 
 import tinker
 from tinker import types
-from tinker._exceptions import RequestFailedError
+from tinker._exceptions import APITimeoutError, RequestFailedError
 from tinker.lib.client_connection_pool_type import ClientConnectionPoolType
 from tinker.lib.public_interfaces.api_future import APIFuture
 from tinker.lib.telemetry import Telemetry, is_user_error
@@ -127,7 +127,7 @@ class _APIFuture(APIFuture[T]):  # pyright: ignore[reportUnusedClass]
                                 request_id=self.request_id,
                                 allow_metadata_only=allow_metadata_only,
                             ),
-                            timeout=45,
+                            timeout=self.holder._retrieve_poll_timeout,
                             extra_headers=headers,
                             max_retries=0,
                         )
@@ -192,6 +192,11 @@ class _APIFuture(APIFuture[T]):  # pyright: ignore[reportUnusedClass]
                     raise ValueError(
                         f"Error retrieving result: {e} with status code {e.status_code=} for {self.request_id=} and expected type {self.model_cls=}"
                     ) from e
+                except APITimeoutError:
+                    # Poll timeouts are expected during long-running computations.
+                    # Retry immediately without backoff — the server simply hadn't
+                    # finished processing within the poll window.
+                    continue
                 except tinker.APIConnectionError as e:
                     if telemetry := self.get_telemetry():
                         current_time = time.time()
@@ -208,7 +213,7 @@ class _APIFuture(APIFuture[T]):  # pyright: ignore[reportUnusedClass]
                             severity="WARNING",
                         )
 
-                    # Retry all connection errors with exponential backoff
+                    # Retry real connection errors with exponential backoff
                     await asyncio.sleep(min(2**connection_error_retries, 30))
                     connection_error_retries += 1
                     continue

--- a/src/tinker/lib/internal_client_holder.py
+++ b/src/tinker/lib/internal_client_holder.py
@@ -33,6 +33,7 @@ T = TypeVar("T")
 
 MAX_REQUESTS_PER_HTTPX_CLIENT = 50
 MAX_CONNECTION_ERROR_RETRIES = 16
+DEFAULT_RETRIEVE_POLL_TIMEOUT = 45
 
 
 class ClientConnectionPool:
@@ -180,6 +181,7 @@ class InternalClientHolder(AsyncTinkerProvider, TelemetryProvider):
         project_id: str | None = None,
         *,
         session_id: str | None = None,
+        retrieve_poll_timeout: float | None = None,
         **kwargs: Any,
     ) -> None:
         self._constructor_kwargs = kwargs
@@ -191,6 +193,16 @@ class InternalClientHolder(AsyncTinkerProvider, TelemetryProvider):
         self._sample_dispatch_bytes_semaphore: BytesSemaphore = BytesSemaphore(5 * 1024 * 1024)
         self._inflight_response_bytes_semaphore: BytesSemaphore = BytesSemaphore(5 * 1024 * 1024)
         self._training_client_lock: threading.Lock = threading.Lock()
+
+        # Retrieve poll timeout: constructor arg > env var > default
+        if retrieve_poll_timeout is not None:
+            self._retrieve_poll_timeout = retrieve_poll_timeout
+        else:
+            env_val = os.environ.get("TINKER_RETRIEVE_POLL_TIMEOUT")
+            if env_val is not None:
+                self._retrieve_poll_timeout = float(env_val)
+            else:
+                self._retrieve_poll_timeout = float(DEFAULT_RETRIEVE_POLL_TIMEOUT)
 
         if session_id is not None:
             # Shadow mode: reuse existing session, can't create new clients

--- a/src/tinker/lib/public_interfaces/service_client.py
+++ b/src/tinker/lib/public_interfaces/service_client.py
@@ -62,12 +62,14 @@ class ServiceClient(TelemetryProvider):
         self,
         user_metadata: dict[str, str] | None = None,
         project_id: str | None = None,
+        retrieve_poll_timeout: float | None = None,
         **kwargs: Any,
     ):
         default_headers = _get_default_headers() | kwargs.pop("default_headers", {})
         self.holder = InternalClientHolder(
             user_metadata=user_metadata,
             project_id=project_id,
+            retrieve_poll_timeout=retrieve_poll_timeout,
             **kwargs,
             default_headers=default_headers,
             _strict_response_validation=True,


### PR DESCRIPTION
## Summary

- **Root cause**: `APITimeoutError` is a subclass of `APIConnectionError`, so the polling loop in `_result_async()` treated normal long-poll timeouts as connection failures and applied exponential backoff (`sleep(2^n)`). For a 24s GPU computation with 45s poll timeout, this added ~93-130s of wasted time per training step.
- **Fix**: Catch `APITimeoutError` before `APIConnectionError` in the polling loop and retry immediately without backoff — poll timeouts are expected during long-running computations, not errors.
- **Configurable poll timeout**: The hardcoded 45s poll timeout is now configurable via `ServiceClient(retrieve_poll_timeout=N)` or `TINKER_RETRIEVE_POLL_TIMEOUT=N` env var. Default remains 45s.

## Test plan

- [ ] Verify existing training workloads (forward_backward, forward_backward_custom, optim_step) complete without regression
- [ ] Confirm training step latency matches raw HTTP baseline (~25s for batch_size=2 instead of ~155s)
- [ ] Test with `TINKER_RETRIEVE_POLL_TIMEOUT=10` env var to verify configurable timeout works
- [ ] Test with `ServiceClient(retrieve_poll_timeout=10)` constructor param
- [ ] Verify real connection errors (e.g. network down) still get exponential backoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)