### PR TITLE
fix(_compat): suppress Pydantic warnings on Python 3.14

### DIFF
--- a/src/tinker/_compat.py
+++ b/src/tinker/_compat.py
@@ -220,3 +220,10 @@ else:
     from functools import cached_property as cached_property
 
     typed_cached_property = cached_property
+
+
+# Suppress Pydantic warnings on Python 3.14+ (until Pydantic V3)
+import sys
+if sys.version_info >= (3, 14):
+    import warnings
+    warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")


### PR DESCRIPTION
Fixes Issue #6.

Good day!

Warmly, RoomWithoutRoof
