### PR TITLE
fix(docs): fwdbwd_result.loss does not exist, use metrics['loss:sum']

### DIFF
--- a/docs/api/trainingclient.md
+++ b/docs/api/trainingclient.md
@@ -108,7 +108,7 @@ optim_future = training_client.optim_step(
 )
 
 fwdbwd_result = await fwdbwd_future
-print(f"Loss: {fwdbwd_result.loss}")
+print(f"Loss: {fwdbwd_result.metrics['loss:sum']}")
 ```
 
 #### `forward_backward_async`

--- a/src/tinker/lib/public_interfaces/training_client.py
+++ b/src/tinker/lib/public_interfaces/training_client.py
@@ -294,7 +294,7 @@ class TrainingClient(TelemetryProvider):
         )
 
         fwdbwd_result = await fwdbwd_future
-        print(f"Loss: {fwdbwd_result.loss}")
+        print(f"Loss: {fwdbwd_result.metrics['loss:sum']}")
         ```
         """
         requests = self._chunked_requests(data)


### PR DESCRIPTION
ForwardBackwardOutput has no .loss attribute. Running the docstring example raises AttributeError. The actual loss is at fwdbwd_result.metrics['loss:sum']. Fixes both the docstring in training_client.py and the generated docs in trainingclient.md. Reproduced on tinker 0.18.0, Python 3.11.