### PR TITLE
fix docs examples for ForwardBackwardOutput metrics access

### DIFF
--- a/docs/api/trainingclient.md
+++ b/docs/api/trainingclient.md
@@ -57,7 +57,7 @@ data = [types.Datum(
 )]
 future = training_client.forward(data, "cross_entropy")
 result = await future
-print(f"Loss: {result.loss}")
+print(f"Loss: {result.metrics['loss:sum']}")
 ```
 
 #### `forward_async`
@@ -108,7 +108,7 @@ optim_future = training_client.optim_step(
 )
 
 fwdbwd_result = await fwdbwd_future
-print(f"Loss: {fwdbwd_result.loss}")
+print(f"Loss: {fwdbwd_result.metrics['loss:sum']}")
 ```
 
 #### `forward_backward_async`
@@ -157,7 +157,6 @@ def custom_loss(data, logprobs_list):
 
 future = training_client.forward_backward_custom(data, custom_loss)
 result = future.result()
-print(f"Custom loss: {result.loss}")
 print(f"Metrics: {result.metrics}")
 ```
 

--- a/src/tinker/lib/public_interfaces/training_client.py
+++ b/src/tinker/lib/public_interfaces/training_client.py
@@ -206,7 +206,7 @@ class TrainingClient(TelemetryProvider):
         )]
         future = training_client.forward(data, "cross_entropy")
         result = await future
-        print(f"Loss: {result.loss}")
+        print(f"Loss: {result.metrics['loss:sum']}")
         ```
         """
         requests = self._chunked_requests(data)
@@ -294,7 +294,7 @@ class TrainingClient(TelemetryProvider):
         )
 
         fwdbwd_result = await fwdbwd_future
-        print(f"Loss: {fwdbwd_result.loss}")
+        print(f"Loss: {fwdbwd_result.metrics['loss:sum']}")
         ```
         """
         requests = self._chunked_requests(data)
@@ -368,7 +368,6 @@ class TrainingClient(TelemetryProvider):
 
         future = training_client.forward_backward_custom(data, custom_loss)
         result = future.result()
-        print(f"Custom loss: {result.loss}")
         print(f"Metrics: {result.metrics}")
         ```
         """


### PR DESCRIPTION
## Summary

This updates `TrainingClient` documentation examples to reflect the actual `ForwardBackwardOutput` shape.

`ForwardBackwardOutput` does not expose a `.loss` attribute. Accessing `result.loss` raises an `AttributeError`.  
For built-in cross-entropy examples, loss is available under:

`result.metrics["loss:sum"]`

For custom loss examples, metrics are user-defined, so the docs now show printing the full `result.metrics` map instead of assuming a `loss:sum` key always exists.

## What changed

- Replaced `.loss` usage in standard forward/forward_backward examples with `metrics["loss:sum"]`
- Updated custom loss examples to print `result.metrics` (without assuming `loss:sum`)

## Why

Running the documented examples as written currently fails with:

`AttributeError: 'ForwardBackwardOutput' object has no attribute 'loss'`

This PR aligns the docs with the real API surface and avoids misleading assumptions in custom-loss workflows.

## Reproduction

```python
fwdbwd_future = await training_client.forward_backward_async(data=[datum], loss_fn="cross_entropy")
fwdbwd_result = await fwdbwd_future.result_async()
print(fwdbwd_result.loss)  # AttributeError
```