### PR TITLE
  Fixes a correctness issue in SamplingClient.compute_logprobs() where the sampling response can omit prompt_logprobs even though the request asked for them.

### DIFF
--- a/src/tinker/lib/public_interfaces/sampling_client.py
+++ b/src/tinker/lib/public_interfaces/sampling_client.py
@@ -22,6 +22,7 @@ from tinker.lib.telemetry_provider import TelemetryProvider
 
 from ..api_future_impl import QueueState, QueueStateObserver, _APIFuture
 from ..retry_handler import RetryConfig, RetryHandler
+from ..retryable_exception import RetryableException
 
 if TYPE_CHECKING:
     from transformers.tokenization_utils import PreTrainedTokenizer
@@ -389,6 +390,10 @@ class SamplingClient(TelemetryProvider, QueueStateObserver):
                 sampling_params=types.SamplingParams(max_tokens=1),
                 include_prompt_logprobs=True,
             )
+            if sample_res.prompt_logprobs is None:
+                raise RetryableException(
+                    "Sampling response omitted prompt_logprobs for a compute_logprobs request"
+                )
             return cast(list[float | None], sample_res.prompt_logprobs)
 
         @capture_exceptions(fatal=True)

--- a/tests/test_sampling_client_compute_logprobs.py
+++ b/tests/test_sampling_client_compute_logprobs.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import Future
+
+import pytest
+
+from tinker import types
+from tinker.lib.public_interfaces.sampling_client import SamplingClient
+from tinker.lib.retryable_exception import RetryableException
+
+
+class _CoroutineHandle:
+    def __init__(self, future: Future):
+        self._future = future
+
+    def future(self) -> Future:
+        return self._future
+
+
+class _DummyHolder:
+    def run_coroutine_threadsafe(self, coro):
+        future: Future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except Exception as exc:
+            future.set_exception(exc)
+        return _CoroutineHandle(future)
+
+    def get_telemetry(self):
+        return None
+
+
+class _RetryOnceHandler:
+    def __init__(self):
+        self.calls = 0
+
+    async def execute(self, func, *args, **kwargs):
+        last_exc = None
+        for _ in range(2):
+            self.calls += 1
+            try:
+                return await func(*args, **kwargs)
+            except RetryableException as exc:
+                last_exc = exc
+        assert last_exc is not None
+        raise last_exc
+
+
+def _make_client(responses: list[types.SampleResponse]):
+    client = object.__new__(SamplingClient)
+    client.holder = _DummyHolder()
+    client.retry_handler = _RetryOnceHandler()
+    client._sampling_client_sidecar_handle = None
+
+    async def _sample_async_impl(*args, **kwargs):
+        del args, kwargs
+        return responses.pop(0)
+
+    client._sample_async_impl = _sample_async_impl
+    return client
+
+
+def test_compute_logprobs_retries_when_prompt_logprobs_missing():
+    prompt = types.ModelInput.from_ints([1, 2, 3])
+    client = _make_client(
+        [
+            types.SampleResponse(sequences=[], prompt_logprobs=None),
+            types.SampleResponse(sequences=[], prompt_logprobs=[-0.1, -0.2, None]),
+        ]
+    )
+
+    result = client.compute_logprobs(prompt).result(timeout=5)
+
+    assert result == [-0.1, -0.2, None]
+    assert client.retry_handler.calls == 2
+
+
+def test_compute_logprobs_raises_if_prompt_logprobs_never_arrive():
+    prompt = types.ModelInput.from_ints([1, 2, 3])
+    client = _make_client(
+        [
+            types.SampleResponse(sequences=[], prompt_logprobs=None),
+            types.SampleResponse(sequences=[], prompt_logprobs=None),
+        ]
+    )
+
+    with pytest.raises(
+        RetryableException, match="omitted prompt_logprobs for a compute_logprobs request"
+    ):
+        client.compute_logprobs(prompt).result(timeout=5)


### PR DESCRIPTION
 Previously, compute_logprobs() blindly returned sample_res.prompt_logprobs, which could be None. This made the SDK silently propagate an invalid result instead of retrying or failing clearly.

  ## Changes

  - Treat missing prompt_logprobs in compute_logprobs() as a RetryableException
  - Let the existing retry handler retry the request automatically
  - Add regression tests covering:
      - retry-then-success when the first response omits prompt_logprobs
      - failure when prompt_logprobs never arrive

  ## Why
Issue #14 reports intermittent compute_logprobs() failures on larger models. The SDK already requests prompt logprobs explicitly for this path, so a response without them is not usable and should not be treated as success.

This change keeps the fix narrow:
  - no API changes
  - no retry-policy changes
  - only compute_logprobs() behavior is tightened when the backend response is incomplete

  ## Testing
  - ruff check on touched files
  - Added targeted regression tests for missing prompt_logprobs behavior

  If you want, I can also give you a shorter maintainer-style version.