### PR TITLE
Fix `checkpoint delete` crashing on valid tinker:// paths due to `list` command shadowing builtin

### DIFF
--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -634,7 +634,7 @@ def cli():
     pass
 
 
-@cli.command()
+@cli.command("list")
 @click.option("--run-id", help="Training run ID")
 @click.option(
     "--limit",
@@ -644,7 +644,7 @@ def cli():
 )
 @click.pass_obj
 @handle_api_errors
-def list(cli_context: CLIContext, run_id: str | None, limit: int) -> None:
+def list_checkpoints(cli_context: CLIContext, run_id: str | None, limit: int) -> None:
     """List checkpoints.
 
     If --run-id is provided, list checkpoints for that specific training run.


### PR DESCRIPTION
## Bug

`tinker checkpoint delete -y tinker://<run-id>/weights/<id>` crashes for **any** well-formed `tinker://` path:

```
Error: Got unexpected extra argument (tinker://<run-id>/weights/<id>)
```

(Malformed paths fail earlier at the `startswith("tinker://")` check, so only valid paths trigger this.)

## Root cause

In `src/tinker/cli/commands/checkpoint.py`, the `list` subcommand is defined as a plain `def list(...)` at module scope. That rebinds the module-global name `list` to the Click command object, **shadowing the `list` builtin for the entire module**. Any builtin `list(...)` call in the module then resolves to the Click command instead of constructing a list.

The `delete` command's no-`--run-id` branch does:

```python
paths_to_delete = list(checkpoint_paths)
```

This invokes the `list` command with the path tuple as argv, which Click rejects as an unexpected extra argument. (The `--run-id` branch uses a comprehension, so it was unaffected.)

The same shadowing also silently affects the `list(...)` calls in `_export_checkpoint_to_hub` and `push_hf` — so this is a class of bug, not a single call site.

## Fix

Rename the function to `list_checkpoints` and preserve the CLI name with `@cli.command("list")`. This restores the `list` builtin across the module and prevents the whole class of bug. No code references the command by its Python symbol (it is registered with the Click group by name and lazy-loaded), so the rename is safe.

```diff
-@cli.command()
+@cli.command("list")
 @click.option("--run-id", help="Training run ID")
 ...
-def list(cli_context: CLIContext, run_id: str | None, limit: int) -> None:
+def list_checkpoints(cli_context: CLIContext, run_id: str | None, limit: int) -> None:
```

## Verification

- `tinker checkpoint list` command name unchanged; group still exposes `list` and `delete`.
- `list` builtin is no longer shadowed at module scope.
- `tests/test_checkpoint_delete.py` passes (20 tests); `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)