### PR TITLE
[codex] Fix checkpoint delete CLI parsing

### DIFF
--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -634,7 +634,7 @@ def cli():
     pass
 
 
-@cli.command()
+@cli.command(name="list")
 @click.option("--run-id", help="Training run ID")
 @click.option(
     "--limit",
@@ -644,7 +644,7 @@ def cli():
 )
 @click.pass_obj
 @handle_api_errors
-def list(cli_context: CLIContext, run_id: str | None, limit: int) -> None:
+def list_checkpoints(cli_context: CLIContext, run_id: str | None, limit: int) -> None:
     """List checkpoints.
 
     If --run-id is provided, list checkpoints for that specific training run.

--- a/tests/test_checkpoint_delete.py
+++ b/tests/test_checkpoint_delete.py
@@ -159,6 +159,38 @@ class TestDeleteCLIValidation:
         result = runner.invoke(cli, ["delete"])
         assert result.exit_code != 0
 
+    def test_explicit_tinker_path_deletes_checkpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tinker.cli.commands import checkpoint
+        from tinker.cli.context import CLIContext
+
+        checkpoint_path = "tinker://run-1/sampler_weights/copy-test"
+        deleted_paths: list[str] = []
+
+        class _Result:
+            def result(self) -> None:
+                return None
+
+        class _Client:
+            def delete_checkpoint_from_tinker_path(self, path: str) -> _Result:
+                deleted_paths.append(path)
+                return _Result()
+
+        def create_rest_client() -> _Client:
+            return _Client()
+
+        monkeypatch.setattr(checkpoint, "create_rest_client", create_rest_client)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            checkpoint.cli,
+            ["delete", "-y", checkpoint_path],
+            obj=CLIContext(format="json"),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert deleted_paths == [checkpoint_path]
+        assert '"deleted_count": 1' in result.output
+
     def test_paths_and_run_id_conflict(self) -> None:
         from tinker.cli.commands.checkpoint import cli
 


### PR DESCRIPTION
## Summary

- Keep the CLI subcommand name `tinker checkpoint list` while renaming its Python function to avoid shadowing the built-in `list`.
- Add a regression test proving `tinker checkpoint delete -y tinker://...` reaches the REST delete path.

## Root cause

`checkpoint.py` defined a Click command function named `list`. The bulk-delete refactor in 0.16.0 later called `list(checkpoint_paths)`, which invoked the Click command object instead of the Python built-in and made the checkpoint path look like an unexpected argument to `checkpoint list`.

## Validation

- `.venv/bin/python -m pytest tests/test_checkpoint_delete.py`
- `.venv/bin/python -m ruff check src/tinker/cli/commands/checkpoint.py tests/test_checkpoint_delete.py`
- `.venv/bin/python -m ruff format --check src/tinker/cli/commands/checkpoint.py tests/test_checkpoint_delete.py`