### PR TITLE
Return JSON for empty checkpoint delete results

### DIFF
--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -976,6 +976,24 @@ def _delete_paths(
                 click.echo(f"  - {path}: {error}")
 
 
+def _print_no_checkpoints_to_delete(run_id: str, format: str) -> None:
+    if format == "json":
+        import json
+
+        click.echo(
+            json.dumps(
+                {
+                    "deleted_count": 0,
+                    "failed": [],
+                    "run_id": run_id,
+                    "matched_count": 0,
+                }
+            )
+        )
+    else:
+        click.echo(f"No checkpoints found for run {run_id} matching filters")
+
+
 @cli.command()
 @click.argument("checkpoint_paths", nargs=-1, required=False)
 @click.option("--run-id", default=None, help="Delete all checkpoints for a training run")
@@ -1063,7 +1081,7 @@ def delete(
         )
 
         if not checkpoints:
-            click.echo(f"No checkpoints found for run {run_id} matching filters")
+            _print_no_checkpoints_to_delete(run_id, cli_context.format)
             return
 
         paths_to_delete = [c.tinker_path for c in checkpoints]

--- a/tests/test_checkpoint_delete.py
+++ b/tests/test_checkpoint_delete.py
@@ -191,6 +191,36 @@ class TestDeleteCLIValidation:
         assert deleted_paths == [checkpoint_path]
         assert '"deleted_count": 1' in result.output
 
+    def test_run_id_no_matches_prints_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tinker.cli.commands import checkpoint
+        from tinker.cli.context import CLIContext
+
+        class _ListResult:
+            def result(self):
+                return type("Response", (), {"checkpoints": []})()
+
+        class _Client:
+            def list_checkpoints(self, run_id: str) -> _ListResult:
+                assert run_id == "run-1"
+                return _ListResult()
+
+        def create_rest_client() -> _Client:
+            return _Client()
+
+        monkeypatch.setattr(checkpoint, "create_rest_client", create_rest_client)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            checkpoint.cli,
+            ["delete", "-y", "--run-id", "run-1"],
+            obj=CLIContext(format="json"),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert '"deleted_count": 0' in result.output
+        assert '"matched_count": 0' in result.output
+        assert '"run_id": "run-1"' in result.output
+
     def test_paths_and_run_id_conflict(self) -> None:
         from tinker.cli.commands.checkpoint import cli
 


### PR DESCRIPTION
## Summary

When `tinker checkpoint delete --run-id ... --format json` matched no checkpoints, the command printed a human-readable sentence instead of JSON. This makes scripting around filtered deletes awkward because the output format changes on the empty-result path.

This PR adds a small JSON empty-result response with:

- `deleted_count: 0`
- `failed: []`
- `run_id`
- `matched_count: 0`

Table output is unchanged.

## Tests

- `.venv/bin/python -m pytest tests/test_checkpoint_delete.py -n 0`
- `.venv/bin/ruff check src/tinker/cli/commands/checkpoint.py tests/test_checkpoint_delete.py`
- `.venv/bin/ruff format --check src/tinker/cli/commands/checkpoint.py tests/test_checkpoint_delete.py`