### PR TITLE
fix(cli): default checkpoint delete concurrency to 1 and add --concurrency

### DIFF
--- a/src/tinker/cli/commands/checkpoint.py
+++ b/src/tinker/cli/commands/checkpoint.py
@@ -916,7 +916,7 @@ def _confirm_deletion(paths: "List[str]", checkpoints: "List[Checkpoint] | None"
     return click.confirm(f"Are you sure you want to delete {count} checkpoint(s)?")
 
 
-_DELETE_CONCURRENCY = 32
+_DEFAULT_DELETE_CONCURRENCY = 1
 
 
 def _delete_one(client: "RestClient", path: str) -> "tuple[str, str] | None":
@@ -932,14 +932,19 @@ def _delete_paths(
     client: "RestClient",
     paths: "List[str]",
     format: str,
+    concurrency: int = _DEFAULT_DELETE_CONCURRENCY,
 ) -> None:
-    """Delete a list of tinker paths concurrently and print results."""
+    """Delete a list of tinker paths and print results.
+
+    Default concurrency is 1 (serial). Higher values can be slower against
+    current API delete contention; see GitHub issue #45.
+    """
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     deleted_count = 0
     failed: "List[tuple[str, str]]" = []
     with (
-        ThreadPoolExecutor(max_workers=_DELETE_CONCURRENCY) as pool,
+        ThreadPoolExecutor(max_workers=concurrency) as pool,
         click.progressbar(
             length=len(paths),
             label="Deleting checkpoints",
@@ -993,6 +998,16 @@ def _delete_paths(
     help="Filter: created after date in UTC (ISO 8601, e.g. 2024-01-01, 2024-01-01T08:00:00Z)",
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@click.option(
+    "--concurrency",
+    type=click.IntRange(min=1),
+    default=_DEFAULT_DELETE_CONCURRENCY,
+    show_default=True,
+    help=(
+        "Max parallel delete requests. Default 1 is fastest against "
+        "current API contention; raise only if needed."
+    ),
+)
 @click.pass_obj
 @handle_api_errors
 def delete(
@@ -1003,6 +1018,7 @@ def delete(
     before: str | None,
     after: str | None,
     yes: bool,
+    concurrency: int,
 ) -> None:
     """Delete one or more checkpoints permanently.
 
@@ -1025,6 +1041,10 @@ def delete(
     Dates are interpreted as UTC. Use full ISO 8601 datetime for precision:
 
         tinker checkpoint delete --run-id <run-id> --before 2024-06-01T08:00:00Z
+
+    Control parallel deletes (default 1; higher values may be slower):
+
+        tinker checkpoint delete --run-id <run-id> --concurrency 1
 
     Only the owner of the training run can delete checkpoints.
 
@@ -1082,7 +1102,7 @@ def delete(
             click.echo("Deletion cancelled.")
             return
 
-    _delete_paths(client, paths_to_delete, cli_context.format)
+    _delete_paths(client, paths_to_delete, cli_context.format, concurrency)
 
 
 @cli.command()

--- a/tests/test_checkpoint_delete.py
+++ b/tests/test_checkpoint_delete.py
@@ -191,6 +191,57 @@ class TestDeleteCLIValidation:
         assert deleted_paths == [checkpoint_path]
         assert '"deleted_count": 1' in result.output
 
+    def test_concurrency_one_deletes_multiple_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tinker.cli.commands import checkpoint
+        from tinker.cli.context import CLIContext
+
+        paths = [
+            "tinker://run-1/weights/0001",
+            "tinker://run-1/weights/0002",
+            "tinker://run-1/sampler_weights/0001",
+        ]
+        deleted_paths: list[str] = []
+
+        class _Result:
+            def result(self) -> None:
+                return None
+
+        class _Client:
+            def delete_checkpoint_from_tinker_path(self, path: str) -> _Result:
+                deleted_paths.append(path)
+                return _Result()
+
+        monkeypatch.setattr(checkpoint, "create_rest_client", lambda: _Client())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            checkpoint.cli,
+            ["delete", "-y", "--concurrency", "1", *paths],
+            obj=CLIContext(format="json"),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert sorted(deleted_paths) == sorted(paths)
+        assert '"deleted_count": 3' in result.output
+
+    def test_concurrency_zero_rejected(self) -> None:
+        from tinker.cli.commands.checkpoint import cli
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["delete", "-y", "tinker://run-1/weights/0001", "--concurrency", "0"]
+        )
+        assert result.exit_code != 0
+
+    def test_concurrency_negative_rejected(self) -> None:
+        from tinker.cli.commands.checkpoint import cli
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["delete", "-y", "tinker://run-1/weights/0001", "--concurrency", "-1"]
+        )
+        assert result.exit_code != 0
+
     def test_paths_and_run_id_conflict(self) -> None:
         from tinker.cli.commands.checkpoint import cli
 


### PR DESCRIPTION
## Summary
- Default `tinker checkpoint delete` concurrency 32 -> 1 (serial), matching the throughput measured in #45 (~2x faster than 32-way under contention).
- Add `--concurrency` to let users override.
- Extend CLI tests for default, valid override, and invalid values.

## Context
Fixes #45. Client-side only; server-side delete contention is out of scope.
Diff kept minimal to avoid conflicting with open PR #48.

## Test plan
- [x] pytest tests/test_checkpoint_delete.py (24 passed)
- [ ] `tinker checkpoint delete --help` shows --concurrency (default 1)
- [x] Invalid `--concurrency 0` fails validation

Made with [Cursor](https://cursor.com)