### PR TITLE
Fix parallel forward-backward gate submission

### DIFF
--- a/src/tinker/lib/public_interfaces/training_client.py
+++ b/src/tinker/lib/public_interfaces/training_client.py
@@ -357,16 +357,23 @@ class TrainingClient(TelemetryProvider):
                     )
 
             if parallel and len(requests) > 1:
-                # Send all chunks in parallel, but submit the first chunk
-                # last.  The server won't process later chunks until the
-                # first one arrives (seq_id ordering), so by the time chunk
-                # 1 lands the rest are already queued and the server can
-                # pick the whole batch together.
-                rest_futures = list(
-                    await asyncio.gather(*[_submit_chunk(rid, d) for rid, d in requests[1:]])
-                )
+                # Start the later chunks first so they can queue behind the
+                # first chunk's seq_id. Do not wait for their acknowledgements
+                # before submitting the first chunk: a later submit failure
+                # must not prevent the first chunk from reaching the server.
+                rest_tasks = [asyncio.create_task(_submit_chunk(rid, d)) for rid, d in requests[1:]]
                 first_rid, first_data = requests[0]
-                first_future = await _submit_chunk(first_rid, first_data)
+                first_task = asyncio.create_task(_submit_chunk(first_rid, first_data))
+                tasks = [first_task, *rest_tasks]
+                try:
+                    first_future = await first_task
+                    rest_futures = list(await asyncio.gather(*rest_tasks))
+                except BaseException:
+                    for task in tasks:
+                        if not task.done():
+                            task.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    raise
                 futures = [first_future] + rest_futures
             else:
                 # gather is safe even when serial — _take_turn orders execution.

--- a/tests/test_training_client_parallel_submit.py
+++ b/tests/test_training_client_parallel_submit.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+import tinker.lib.public_interfaces.training_client as training_client_module
+from tinker import APIConnectionError, types
+from tinker.lib.public_interfaces.training_client import TrainingClient
+
+
+def _datum(token: int) -> types.Datum:
+    return types.Datum(
+        model_input=types.ModelInput.from_ints([token, token + 1]),
+        loss_fn_inputs={
+            "target_tokens": types.TensorData(
+                data=[token + 1],
+                dtype="int64",
+                shape=[1],
+            )
+        },
+    )
+
+
+async def test_parallel_submit_attempts_gate_when_later_chunk_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    submitted: list[int] = []
+
+    class Holder:
+        _client_config = SimpleNamespace(
+            parallel_fwdbwd_chunks=True,
+            proto_write_fwdbwd=False,
+        )
+
+        async def execute_with_retries(
+            self,
+            _send: Any,
+            request_id: int,
+            _data: list[types.Datum],
+        ) -> object:
+            seq_id = request_id + 1
+            submitted.append(seq_id)
+            await asyncio.sleep(0)
+            if seq_id == 2:
+                raise APIConnectionError(
+                    request=httpx.Request(
+                        "POST",
+                        "https://trainer.test/api/v1/forward_backward",
+                    )
+                )
+            return object()
+
+        def run_coroutine_threadsafe(self, coroutine: Any) -> asyncio.Task[Any]:
+            return asyncio.ensure_future(coroutine)
+
+        def get_telemetry(self) -> None:
+            return None
+
+    class FakeAPIFuture:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    client = TrainingClient(
+        holder=Holder(),  # type: ignore[arg-type]
+        model_seq_id=1,
+        model_id="model",
+    )
+
+    def chunked_requests(
+        _data: list[types.Datum],
+    ) -> list[tuple[int, list[types.Datum]]]:
+        return [
+            (0, [_datum(1)]),
+            (1, [_datum(10)]),
+            (2, [_datum(20)]),
+        ]
+
+    monkeypatch.setattr(
+        client,
+        "_chunked_requests",
+        chunked_requests,
+    )
+    monkeypatch.setattr(
+        training_client_module,
+        "_APIFuture",
+        FakeAPIFuture,
+    )
+
+    with pytest.raises(APIConnectionError):
+        await client._run_fwd_bwd(
+            [_datum(1)],
+            "cross_entropy",
+            None,
+            forward_only=False,
+        )
+
+    assert 2 in submitted
+    assert 3 in submitted
+    assert 1 in submitted


### PR DESCRIPTION
## Summary

- start later parallel chunks first without waiting for all of their acknowledgements
- always submit and await the first/gate chunk before observing failures from later chunks
- cancel and collect outstanding submission tasks when any submission fails
- add a regression test proving a later `APIConnectionError` cannot prevent the gate chunk from being attempted

## Root cause

The parallel forward-backward path awaited `gather()` for every later chunk before it called `_submit_chunk()` for the first chunk. If any later submission exhausted its retries, execution left the method before the first/gate sequence was ever sent. The trainer could then retain all later sequences while waiting on a permanent sequence gap.

## Validation

- `uv run --frozen --python 3.12 pytest tests/test_training_client_parallel_submit.py -n 0`
- `uv run --frozen --python 3.12 ruff check src/tinker/lib/public_interfaces/training_client.py tests/test_training_client_parallel_submit.py`
- `uv run --frozen --python 3.12 ruff format --check src/tinker/lib/public_interfaces/training_client.py tests/test_training_client_parallel_submit.py`
- `uv run --frozen --python 3.12 pyright tests/test_training_client_parallel_submit.py`
- local fake HTTP trainer reproduction: a truncated response for a later chunk still raises `APIConnectionError`, while the patched client now sends the gate chunk